### PR TITLE
css link fixed

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -20,7 +20,7 @@
   <!--<link rel="stylesheet" href="/public/styles/reset.css">-->
 
   <!-- our own css file -->
-  <link rel="stylesheet" href="/views/style.css">
+  <link rel="stylesheet" href="public/css/styles.css">
 </head>
 
 <body>


### PR DESCRIPTION
For some reason the css files are in the views folder, but there are no views in that folder. Please return the css files to the public/css folder